### PR TITLE
Update flake to latest thorium version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1708655239,
+        "narHash": "sha256-ZrP/yACUvDB+zbqYJsln4iwotbH6CTZiTkANJ0AgDv4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "cbc4211f0afffe6dfd2478a62615dd5175a13f9a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,61 +1,132 @@
 {
-  description= "Thorium using Nix Flake";
-  inputs={
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  };
-  outputs = { self, nixpkgs, ... }:
-  {
-    packages.x86_64-linux.thorium = let
-      pkgs = import nixpkgs { system = "x86_64-linux"; };
-      name = "thorium";
-      version = "117.0.5938.157 - 53";
-      src = pkgs.fetchurl {
-        url = "https://github.com/Alex313031/thorium/releases/download/M117.0.5938.157/Thorium_Browser_117.0.5938.157_x64.AppImage";
-        sha256 = "sha256-dlfClBbwSkQg4stKZdSgNg3EFsWksoI21cxRG5SMrOM=";
-      };
-      appimageContents = pkgs.appimageTools.extractType2 { inherit name src; };
-    in
-    pkgs.appimageTools.wrapType2 {
-      inherit name version src;
-      extraInstallCommands = ''
-        install -m 444 -D ${appimageContents}/thorium-browser.desktop $out/share/applications/thorium-browser.desktop
-        install -m 444 -D ${appimageContents}/thorium.png $out/share/icons/hicolor/512x512/apps/thorium.png
-        substituteInPlace $out/share/applications/thorium-browser.desktop \
-    	  --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
-      '';
+  description = "Thorium using Nix Flake";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: {
+    ##### x86_64-linux #####
+    packages.x86_64-linux = let
+      pkgs = import nixpkgs {system = "x86_64-linux";};
+    in {
+      thorium-avx = let
+        pkgs = import nixpkgs {system = "x86_64-linux";};
+        name = "thorium-avx";
+        version = "121.0.6167.204 - 56";
+        src = pkgs.fetchurl {
+          url = "https://github.com/Alex313031/thorium/releases/download/M121.0.6167.204/thorium_browser_121.0.6167.204_AVX.AppImage";
+          sha256 = "sha256-2PJxnKzppjHrYQnGYYe1BG0075FwDdnjY0JI2X5AIvQ=";
+        };
+        appimageContents = pkgs.appimageTools.extractType2 {inherit name src;};
+      in
+        pkgs.appimageTools.wrapType2 {
+          inherit name version src;
+          extraInstallCommands = ''
+            install -m 444 -D ${appimageContents}/thorium-browser.desktop $out/share/applications/thorium-browser.desktop
+            install -m 444 -D ${appimageContents}/thorium.png $out/share/icons/hicolor/512x512/apps/thorium.png
+            substituteInPlace $out/share/applications/thorium-browser.desktop \
+            --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
+          '';
+        };
+
+      thorium-avx2 = let
+        pkgs = import nixpkgs {system = "x86_64-linux";};
+        name = "thorium-avx2";
+        version = "121.0.6167.204 - 56";
+        src = pkgs.fetchurl {
+          url = "https://github.com/Alex313031/thorium/releases/download/M121.0.6167.204/thorium_browser_121.0.6167.204_AVX2.AppImage";
+          sha256 = "sha256-HANrDUv/oFW2uWLSYilTCzdnZDY1yuqhLo/jRQil3QA=";
+        };
+        appimageContents = pkgs.appimageTools.extractType2 {inherit name src;};
+      in
+        pkgs.appimageTools.wrapType2 {
+          inherit name version src;
+          extraInstallCommands = ''
+            install -m 444 -D ${appimageContents}/thorium-browser.desktop $out/share/applications/thorium-browser.desktop
+            install -m 444 -D ${appimageContents}/thorium.png $out/share/icons/hicolor/512x512/apps/thorium.png
+            substituteInPlace $out/share/applications/thorium-browser.desktop \
+            --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
+          '';
+        };
+
+      thorium-sse3 = let
+        pkgs = import nixpkgs {system = "x86_64-linux";};
+        name = "thorium-sse3";
+        version = "121.0.6167.204 - 56";
+        src = pkgs.fetchurl {
+          url = "https://github.com/Alex313031/thorium/releases/download/M121.0.6167.204/thorium_browser_121.0.6167.204_SSE3.AppImage";
+          sha256 = "sha256-G+Z85w7d7YT/03tqcH1VMJGoenoegcttbxz38u0JWcI=";
+        };
+        appimageContents = pkgs.appimageTools.extractType2 {inherit name src;};
+      in
+        pkgs.appimageTools.wrapType2 {
+          inherit name version src;
+          extraInstallCommands = ''
+            install -m 444 -D ${appimageContents}/thorium-browser.desktop $out/share/applications/thorium-browser.desktop
+            install -m 444 -D ${appimageContents}/thorium.png $out/share/icons/hicolor/512x512/apps/thorium.png
+            substituteInPlace $out/share/applications/thorium-browser.desktop \
+            --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
+          '';
+        };
+
+      # AVX is compatible with most CPUs
+      default = self.packages.x86_64-linux.thorium-avx;
     };
 
-    packages.x86_64-linux.default = self.packages.x86_64-linux.thorium;
-    apps.x86_64-linux.thorium = {
-      type = "app";
-      program = "${self.packages.x86_64-linux.thorium}/bin/thorium";
-    };
-    apps.x86_64-linux.default = self.apps.x86_64-linux.thorium;
-    # -----------------------------------------------------------
-    packages.aarch64-linux.thorium = let
-      pkgs = import nixpkgs { system = "aarch64-linux"; };
-      name = "thorium";
-      version = "117.0.5938.157 - 53";
-      src = pkgs.fetchurl {
-        url = "https://github.com/Alex313031/Thorium-Raspi/releases/download/M117.0.5938.157/Thorium_Browser_117.0.5938.157_arm64.AppImage";
-        sha256 = "";
+    apps.x86_64-linux = {
+      thorium-avx = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.thorium-avx}/bin/thorium";
       };
-      appimageContents = pkgs.appimageTools.extractType2 { inherit name src; };
-    in
-    pkgs.appimageTools.wrapType2 {
-      inherit name version src;
-      extraInstallCommands = ''
-        install -m 444 -D ${appimageContents}/thorium-browser.desktop $out/share/applications/thorium-browser.desktop
-        install -m 444 -D ${appimageContents}/thorium.png $out/share/icons/hicolor/512x512/apps/thorium.png
-        substituteInPlace $out/share/applications/thorium-browser.desktop \
-    	  --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
-      '';
+
+      thorium-avx2 = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.thorium-avx2}/bin/thorium";
+      };
+
+      thorium-sse3 = {
+        type = "app";
+        program = "${self.packages.x86_64-linux.thorium-sse3}/bin/thorium";
+      };
+
+      default = self.apps.x86_64-linux.thorium-avx;
     };
-    packages.aarch64-linux.default = self.packages.aarch64-linux.thorium;
-    apps.aarch64-linux.thorium = {
-      type = "app";
-      program = "${self.packages.aarch64-linux.thorium}/bin/thorium";
+
+    ##### aarch64-linux #####
+    packages.aarch64-linux = {
+      thorium = let
+        pkgs = import nixpkgs {system = "aarch64-linux";};
+        name = "thorium";
+        version = "121.0.6167.204 - 6";
+        src = pkgs.fetchurl {
+          url = "https://github.com/Alex313031/Thorium-Raspi/releases/download/M121.0.6167.204/Thorium_Browser_121.0.6167.204_arm64.AppImage";
+          sha256 = "sha256-gS3/f7wq5adOLZuS2T8SWfme/Z1bFqHSpMLUsENKlcw=";
+        };
+        appimageContents = pkgs.appimageTools.extractType2 {inherit name src;};
+      in
+        pkgs.appimageTools.wrapType2 {
+          inherit name version src;
+          extraInstallCommands = ''
+            install -m 444 -D ${appimageContents}/thorium-browser.desktop $out/share/applications/thorium-browser.desktop
+            install -m 444 -D ${appimageContents}/thorium.png $out/share/icons/hicolor/512x512/apps/thorium.png
+            substituteInPlace $out/share/applications/thorium-browser.desktop \
+            --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${name} %U'
+          '';
+        };
+
+      default = self.packages.aarch64-linux.thorium;
     };
-    apps.aarch64-linux.default = self.apps.aarch64-linux.thorium;
+
+    apps.aarch64-linux = {
+      thorium = {
+        type = "app";
+        program = "${self.packages.aarch64-linux.thorium}/bin/thorium";
+      };
+
+      default = self.apps.aarch64-linux.thorium;
+    };
   };
 }


### PR DESCRIPTION
Also adds AVX, AVX2 and SSE3 versions to x86_64-linux.

I tested all versions on x86_64 and arm64 and they all work perfectly.